### PR TITLE
Import matomo in main to load matomo scripts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import "@gouvfr/dsfr/dist/dsfr/dsfr.module"
 
 import App from './App.vue'
 import store from './store'
+import matomo from './matomo'  // needed to load matomo scripts
 import i18n from './i18n'
 
 Vue.use(VueResource)


### PR DESCRIPTION
Re-import matomo script [to fix matomo stats](https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=263&period=range&date=previous30#?period=day&date=2024-03-15&category=Dashboard_Dashboard&subcategory=1&idSite=263).
The script had been wrongly removing in [this PR](https://github.com/datagouv/explore.data.gouv.fr/commit/30443059fcab9b2076691c76942b2a0765adcced#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L10).