### PR TITLE
Fix tabular scroll bar

### DIFF
--- a/src/apps/tabular/DatasetView.vue
+++ b/src/apps/tabular/DatasetView.vue
@@ -1,9 +1,7 @@
 <template>
-    <div>
-        <span v-if="dgvInfos.resource">
-            <resource-view></resource-view>
-        </span>
-    </div>
+  <div v-if="dgvInfos.resource">
+    <resource-view></resource-view>
+  </div>
 </template>
 
 <script>

--- a/src/apps/tabular/ResourceView.vue
+++ b/src/apps/tabular/ResourceView.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="resource-view">
         <header-apps
             :formHref="formHref()"
             appName="Explorateur de données"
@@ -191,6 +191,15 @@ export default {
 </script>
 
 <style scoped>
+#resource-view {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  /* Use svh on newer devices, useful for mobile users */
+  height: 100svh;
+  overflow: hidden;
+}
+
 .subheader{
   background-color:#3558A2;
   display: flex;

--- a/src/apps/tabular/ResourceView.vue
+++ b/src/apps/tabular/ResourceView.vue
@@ -195,8 +195,8 @@ export default {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  /* Use svh on newer devices, useful for mobile users */
-  height: 100svh;
+  /* Use dvh on newer devices, useful for mobile users */
+  height: 100dvh;
   overflow: hidden;
 }
 

--- a/src/apps/tabular/views/menuResource.vue
+++ b/src/apps/tabular/views/menuResource.vue
@@ -13,13 +13,13 @@
         <div class="menu-buttons">
             <div class="menu-button">
                 <div v-if="dgvInfos.resource">
-                    <div class="fr-col-auto" style="width: 100%">
+                    <div class="fr-col-auto">
                         <button
                         :disabled="doesntHaveFilter"
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-filter-line"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-filter-line"
+                        :class="{'fr-btn--icon-left': filters.length > 0}"
                         data-fr-opened="false"
                         aria-controls="fr-modal-filters"
-                        :style="filters.length > 0 ? '' : 'padding-right: 2px;'"
                         >
                             <span v-if="hasActivefilters" class="fr-badge fr-badge--blue-cumulus">{{countActiveFilters}}</span>
                         </button>
@@ -47,8 +47,7 @@
                     <a
                         download
                         :href="dgvInfos.resource.latest"
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
-                        style="padding-right: 2px;"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-download-line"
                     ></a>
                     </span>
                 </div>
@@ -146,7 +145,7 @@ export default {
     border-bottom: 1px solid #EEEEEE;
 }
 
-@media (min-width: 70em) {
+@media (min-width: 62em) {
     .menu-resource {
         flex-direction: row;
         justify-content: space-between;
@@ -165,7 +164,7 @@ export default {
     }
 }
 
-@media (max-width: 70em) {
+@media (max-width: 62em) {
     .menu-resource {
         align-items: flex-start;
     }
@@ -185,13 +184,13 @@ export default {
     }
 }
 
-@media (max-width: 35em) {
+@media (max-width: 36em) {
     .menu-counts {
         display: none;
     }
 }
 
-@media (min-width: 35em) {
+@media (min-width: 36em) {
     .menu-counts {
         display: flex;
         align-items: center;


### PR DESCRIPTION
This PR locks the ResourceView at 100(d)vh to put the scrollbar to be at the bottom of the screen and not at the bottom of the table.

Closes https://github.com/datagouv/data.gouv.fr/issues/1346

It also fixes some icon buttons with padding issues and aligns the media queries with the DSFR breakpoints.

Dynamic viewport is explained here : https://developer.mozilla.org/en-US/docs/Web/CSS/length#dynamic
In case of performance issues on mobile, we can use [`svh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#small) instead.