### PR TITLE
fix(carburants): fix S3 data url

### DIFF
--- a/src/apps/carburants/AppCarburant.vue
+++ b/src/apps/carburants/AppCarburant.vue
@@ -284,6 +284,7 @@
 <script>
 
 import store from './store'
+import { carburantsDataUrl } from '@/config'
 
 import HeaderApps from '@/views/HeaderApps'
 
@@ -385,7 +386,7 @@ export default {
       zoom: initialState.zoom
     }));
     
-    fetch('https://object.files.data.gouv.fr/data-pipeline-open/carburants/latest_france.geojson', {
+    fetch(carburantsDataUrl + '/latest_france.geojson', {
         compress: false,
         headers: { "accept-encoding": "gzip" },
     })
@@ -476,7 +477,7 @@ export default {
     })
 
 
-    fetch('https://object.files.data.gouv.fr/data-pipeline-open/carburants/daily_prices.json')
+    fetch(carburantsDataUrl + '/daily_prices.json')
     .then((response) => {
         return response.json()
     })
@@ -497,7 +498,7 @@ export default {
   methods: {
     updateDate(val){
 
-      fetch('https://object.files.data.gouv.fr/data-pipeline-open/carburants/historique/' + val + '.json')
+      fetch(carburantsDataUrl + '/historique/' + val + '.json')
       .then((response) => {
           return response.json()
       })

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,7 @@ export const dataGouvUrl = "https://www.data.gouv.fr/fr/"
 export const dataGouvUrlApi = "https://www.data.gouv.fr/api/"
 export const matomoUrl = "https://stats.data.gouv.fr/"
 export const matomoSiteId = process.env.VUE_APP_MATOMO_SITE_ID
+export const carburantsDataUrl = "https://data-pipeline-open.s3.sbg.io.cloud.ovh.net/carburants"
 export default configSite
 
 /**


### PR DESCRIPTION
https://explore.data.gouv.fr/fr/prix-carburants is stuck on 25/06/2026 because it uses the old S3 bucket.

Update the data URL to fetch the latest data.